### PR TITLE
Configure CI workflow jobs to test CloudFormation templates generated by the CDK

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -51,10 +51,31 @@ jobs:
         with:
           input_path: cdk.out
 
+  taskcat:
+    name: Run taskcat tests
+    runs-on: ubuntu-latest
+    needs: [cdk_synth]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: cdk.out
+          path: cdk.out
+      - uses: actions/setup-python@v2
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+      - uses: ShahradR/action-taskcat@develop
+        with:
+          commands: test run
+
   release:
     name: Create release
     runs-on: ubuntu-latest
-    needs: [pre-commit, vale, cdk_synth, cfn_nag]
+    needs: [pre-commit, vale, cdk_synth, cfn_nag, taskcat]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,11 +22,39 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  cdk_synth:
+    name: Synthesize CloudFormation scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.2
+        with:
+          node-version: 12
+      - run: npm install
+      - run: npm install -g aws-cdk typescript ts-node
+      - run: cdk synth "*" --output cdk.out
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cdk.out
+          path: cdk.out/*.template.json
+
+  cfn_nag:
+    name: Run cfn_nag checks
+    runs-on: ubuntu-latest
+    needs: [cdk_synth]
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: cdk.out
+          path: cdk.out
+      - uses: stelligent/cfn_nag@master
+        with:
+          input_path: cdk.out
+
   release:
     name: Create release
     runs-on: ubuntu-latest
-    needs: [pre-commit, vale]
-    if: ${{ needs.pre-commit.result == 'success' }}
+    needs: [pre-commit, vale, cdk_synth, cfn_nag]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,6 +22,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  tests:
+    name: Run Jest tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.0
+        with:
+          node-version: 14
+      - run: npm install
+      - run: npm test
+      - name: Upload coverage information
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage
+          path: coverage/
+
   cdk_synth:
     name: Synthesize CloudFormation scripts
     runs-on: ubuntu-latest

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -1,0 +1,10 @@
+---
+project:
+  name: cloudformation-release-pipeline
+  regions:
+    - ca-central-1
+  s3_bucket: brokentech-cfn
+
+tests:
+  default:
+    template: ./cdk.out/TestCdkStack.template.json


### PR DESCRIPTION
Configure the CI workflow jobs to test the CloudFormation templates generated by the CDK. Specifically, this pull request add the following jobs:

- Jest to test the CloudFormation stacks using the [@aws/assert](https://github.com/aws/aws-cdk/tree/master/packages/%40aws-cdk/assert) package
- [stelligent/cfn_nag](https://github.com/stelligent/cfn_nag/blob/master/github-action/README.md) to lint the CloudFormation templates and ensure they meet best practices
- [ShahradR/action-taskcat](https://github.com/ShahradR/action-taskcat) to run taskcat and verify that the CloudFormation templates can be deployed to the target regions

Because the last two only run against CloudFormation templates in either JSON on YAML formats, we run `cdk synth` in the workflow to synthesize the TypeScript CDK code into JSON or YAML before calling cfn_nag and taskcat.