### PR TITLE
chore: fix interval for npm Dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,7 +11,7 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: live
+      interval: daily
     commit-message:
       prefix: fix
       prefix-development: chore


### PR DESCRIPTION
Update the `schedule.interval` value for the Node.js Dependabot configuration. The `live` value is not valid for the GitHub-native Dependabot configuration.