### PR TITLE
fix: remove hardcoded pipeline name

### DIFF
--- a/lib/release-pipeline-stack.ts
+++ b/lib/release-pipeline-stack.ts
@@ -58,7 +58,6 @@ export class ReleasePipelineStack extends cdk.Stack {
     });
 
     const pipeline = new Pipeline(this, "codepipeline", {
-      pipelineName: "codepipeline",
       crossAccountKeys: false,
       stages: [
         {

--- a/test/release-pipeline-stack.test.ts
+++ b/test/release-pipeline-stack.test.ts
@@ -25,6 +25,14 @@ describe("the CloudFormation stack", () => {
   });
 });
 describe("the CodePipeline pipeline", () => {
+  it("is not named", () => {
+    expectCDK(stack).notTo(
+      haveResourceLike("AWS::CodePipeline::Pipeline", {
+        Name: stringLike("*"),
+      })
+    );
+  });
+
   it("triggers on GitHub deployments", () => {
     expectCDK(stack).to(
       haveResourceLike("AWS::CodePipeline::Webhook", {


### PR DESCRIPTION
Remove the hardcoded `codepipeline` name for the AWS CodePipeline resource and let CloudFormation automatically generate a random name. This allows multiple stacks to be deployed in parallel.

Prior to this change, multiple taskcat runs would interfere with each other, causing all but one GitHub workflow execution to fail.